### PR TITLE
chore: ignore yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # - Do not allow installed node modules to be committed. Doing `npm install -d` will bring them in root or other places.
 node_modules
 
+# Ignore lock files
+yarn.lock
+
 # - Do not commit any log file from anywhere
 *.log
 *.log.*


### PR DESCRIPTION
Ignore `yarn.lock` file to prevent getting commited accidently.